### PR TITLE
Fixes error handling in filesystem Open

### DIFF
--- a/fsio.go
+++ b/fsio.go
@@ -127,6 +127,8 @@ func (fs *FileSystem) Open(p Path, offset, length int64, buffSize int) (io.ReadC
 		if err != nil {
 			return nil, err
 		}
+
+		return nil, fmt.Errorf("Open(%s) - File not opened.  Server returned status %v", p.Name, rsp.StatusCode)
 	}
 
 	return rsp.Body, nil


### PR DESCRIPTION
Open propagates errors when the api call response code is not a 200.