### PR TITLE
Make MaxIdleConnsPerHost configurable.

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -16,6 +16,7 @@ type Configuration struct {
 	DisableKeepAlives     bool
 	DisableCompression    bool
 	ResponseHeaderTimeout time.Duration
+	MaxIdleConnsPerHost   int
 }
 
 func NewConfiguration() *Configuration {

--- a/fs.go
+++ b/fs.go
@@ -60,6 +60,7 @@ func NewFileSystem(conf Configuration) (*FileSystem, error) {
 
 				return c, nil
 			},
+			MaxIdleConnsPerHost: conf.MaxIdleConnsPerHost,
 		},
 	}
 	return fs, nil


### PR DESCRIPTION
Fixes some issues we ran into when doing many concurrent requests from many goroutines.