### PR TITLE
Use ResponseHeaderTimeout specified in Configuration and reuse http.Transport

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -61,6 +61,7 @@ func NewFileSystem(conf Configuration) (*FileSystem, error) {
 				return c, nil
 			},
 			MaxIdleConnsPerHost: conf.MaxIdleConnsPerHost,
+			ResponseHeaderTimeout: conf.ResponseHeaderTimeout,
 		},
 	}
 	return fs, nil

--- a/fsio.go
+++ b/fsio.go
@@ -54,9 +54,8 @@ func (fs *FileSystem) Create(
 	}
 
 	// take over default transport to avoid redirect
-	tr := &http.Transport{}
 	req, _ := http.NewRequest("PUT", u.String(), nil)
-	rsp, err := tr.RoundTrip(req)
+	rsp, err := fs.transport.RoundTrip(req)
 	if err != nil {
 		return false, err
 	}
@@ -153,9 +152,8 @@ func (fs *FileSystem) Append(data io.Reader, p Path, buffersize int) (bool, erro
 	}
 
 	// take over default transport to avoid redirect
-	tr := &http.Transport{}
 	req, _ := http.NewRequest("POST", u.String(), nil)
-	rsp, err := tr.RoundTrip(req)
+	rsp, err := fs.transport.RoundTrip(req)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
* Use ResponseHeaderTimeout specified in the Configuration when creating http.Client.
* http.Transport should be reused instead of created as needed.