### PR TITLE
Send TCP keep-alives.

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -10,6 +10,7 @@ import "net"
 import "net/http"
 import "net/url"
 import "io/ioutil"
+import "time"
 
 const (
 	OP_OPEN                  = "OPEN"
@@ -51,14 +52,10 @@ func NewFileSystem(conf Configuration) (*FileSystem, error) {
 		Config: conf,
 	}
 	fs.transport = &http.Transport{
-		Dial: func(netw, addr string) (net.Conn, error) {
-			c, err := net.DialTimeout(netw, addr, conf.ConnectionTimeout)
-			if err != nil {
-				return nil, err
-			}
-
-			return c, nil
-		},
+		Dial: (&net.Dialer{
+			Timeout:   conf.ConnectionTimeout,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
 		MaxIdleConnsPerHost:   conf.MaxIdleConnsPerHost,
 		ResponseHeaderTimeout: conf.ResponseHeaderTimeout,
 	}


### PR DESCRIPTION
From https://github.com/golang/go/blob/go1.6.3/src/net/http/transport.go#L28

Not sure why we were not sending them before.