### PR TITLE
add Content-type to FileSystem.Create

### DIFF
--- a/fsio.go
+++ b/fsio.go
@@ -19,7 +19,8 @@ func (fs *FileSystem) Create(
 	blocksize uint64,
 	replication uint16,
 	permission os.FileMode,
-	buffersize uint) (bool, error) {
+	buffersize uint,
+	contenttype string) (bool, error) {
 
 	params := map[string]string{"op": OP_CREATE}
 	params["overwrite"] = strconv.FormatBool(overwrite)
@@ -55,6 +56,10 @@ func (fs *FileSystem) Create(
 
 	// take over default transport to avoid redirect
 	req, _ := http.NewRequest("PUT", u.String(), nil)
+	// set content type
+	if contenttype != "" {
+		req.Header.Set("Content-Type", contenttype)
+	}
 	rsp, err := fs.transport.RoundTrip(req)
 	if err != nil {
 		return false, err

--- a/fsio.go
+++ b/fsio.go
@@ -56,10 +56,6 @@ func (fs *FileSystem) Create(
 
 	// take over default transport to avoid redirect
 	req, _ := http.NewRequest("PUT", u.String(), nil)
-	// set content type
-	if contenttype != "" {
-		req.Header.Set("Content-Type", contenttype)
-	}
 	rsp, err := fs.transport.RoundTrip(req)
 	if err != nil {
 		return false, err
@@ -73,6 +69,10 @@ func (fs *FileSystem) Create(
 	}
 
 	req, _ = http.NewRequest("PUT", u.String(), data)
+	// set content type
+	if contenttype != "" {
+		req.Header.Set("Content-Type", contenttype)
+	}
 	rsp, err = fs.client.Do(req)
 	if err != nil {
 		fmt.Errorf("FileSystem.Create(%s) - bad url: %s", loc, err.Error())

--- a/fsio_test.go
+++ b/fsio_test.go
@@ -34,6 +34,7 @@ func Test_Create(t *testing.T) {
 		0,
 		0700,
 		0,
+		"",
 	)
 
 	if err != nil {

--- a/fsshell.go
+++ b/fsshell.go
@@ -126,7 +126,8 @@ func (shell FsShell) Put(localFile string, hdfsPath string, overwrite bool) (boo
 		134217728,
 		3,
 		0644,
-		4096)
+		4096,
+		"")
 
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Sometimes it fails to upload file to hdfs because of not able to specify the content-type. Default content-type is text/html.
So how do you think this PR?